### PR TITLE
Small tweak adding missing field to example GraphQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ export const Layout = () => {
                         }
                         twitter {
                             username
+                            cardType
                         }
                         wikipedia {
                             url


### PR DESCRIPTION
Just another small docs tweak, without this `cardType` field twitter cards don't validate so it's important and useful to provide in the code I imagine most people will copy and paste directly